### PR TITLE
Prevent predictable bullet insertion

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -25,7 +25,7 @@ export class Plugin extends AbstractPlugin {
     private readonly consecutivePullMultipliers = new Map<number, number>();
 
     constructor() {
-        super("Russian Roulette", "1.1.0");
+        super("Russian Roulette", "1.1.1");
     }
 
     /**

--- a/revolver.ts
+++ b/revolver.ts
@@ -29,11 +29,13 @@ export class Revolver {
      * @return True if a bullet was loaded, or false if there were no more empty chambers.
      */
     public insertBullet(): boolean {
-        for (let i = 0; i < this.chambers.length; i++) {
-            if (!this.chambers[i]) {
-                this.chambers[i] = true;
-                return true;
-            }
+        // Find all available open positions, then insert the bullet into a random position.
+        // This fixes an exploit where players could predict where a bullet gets inserted and thus generate lots of cash.
+        const openPositions = this.chambers.flatMap((c, i) => !c ? i : []);
+        if(openPositions.length > 0) {
+            const randomChamberIndex = openPositions[Math.floor(Math.random() * openPositions.length)];
+            this.chambers[randomChamberIndex] = true;
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Fixes exploit where players could predict where the current gun index was, and thus where a bullet got inserted. Which made them able to make a ton of money. Bullets are now inserted at a random location